### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ long_description_content_type = text/markdown
 
 [options]
 install_requires =
-    sqlalchemy
+    sqlalchemy >= 1.4
     colorlog
 
 python_requires = >= 3.8


### PR DESCRIPTION
`session = Session()` is not supported until SQLAlchemy >= 1.4, [details](https://stackoverflow.com/questions/43429942/attributeerror-enter-using-with-statement-sqlalchemy-session)