### PR TITLE
Add Abstract Support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ install_requires =
     colorlog
     beautifulsoup4
     nltk
+    abc
+    selenium
 
 python_requires = >= 3.8
 packages = find:

--- a/top4grep/abstract.py
+++ b/top4grep/abstract.py
@@ -1,0 +1,173 @@
+"""
+Test: python3 -m top4grep.abstract
+"""
+import re
+import requests
+from abc import ABC, abstractmethod
+from bs4 import BeautifulSoup
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import TimeoutException
+from urllib.parse import urlparse, urlunparse
+
+from .utils import new_logger
+
+logger = new_logger('PaperAbstract')
+logger.setLevel('WARNING')
+
+class BasePaperAbstract(ABC):
+    def get_abstract(self, paper_html, title, authors):
+        # import ipdb; ipdb.set_trace()
+        # logger.debug(f"abstracting {paper_html}, title: {title}")
+        try:
+            publisher_url = self.get_publisher_url(paper_html)
+        except Exception as e:
+            logger.debug(f"Failed to obtain publisher URL. Paper: {title}")
+            return ""
+        else:
+            try:
+                return self.get_abstract_from_publisher(publisher_url, authors)
+            except Exception as e:
+                logger.debug(f"Failed to extract abstract from publisher URL {publisher_url}.")
+                return ""
+
+    def get_publisher_url(self, paper_html):
+        ee = paper_html.find('li', {'class': 'ee'})
+        publisher_url = ee.find('a').get('href')
+        return publisher_url
+
+    @abstractmethod
+    def get_abstract_from_publisher(self, url, authors):
+        pass
+
+class AbstractNDSS(BasePaperAbstract):
+    def get_abstract_from_publisher(self, url, authors):
+        logger.debug(f'URL: {url}')
+        r = requests.get(url)
+        assert r.status_code == 200
+
+        html = BeautifulSoup(r.text, 'html.parser')
+        paper_data = html.find('div', {'class': 'paper-data'})
+        if paper_data is not None:
+            abstract_paragraphs = filter(lambda x: x.text != '' and not authors[0] in x.text, paper_data.find_all('p'))
+            ap_list = [x.text for x in abstract_paragraphs]
+            return '\n'.join(ap_list)
+        else:
+            abstract_paragraphs = html.find(string=re.compile("Abstract:")).find_next(recursive=False)
+            return abstract_paragraphs.get_text(separator='\n')
+
+
+class AbstractSP(BasePaperAbstract):
+    def has_abstract_sibling(self, tag):
+        return any(sibling for sibling in tag.find_all_next() if sibling.get_text(strip=True) == 'Abstract')
+   
+    def update_url(self, url):
+        parsed_url = urlparse(url)
+        ieee_netloc = 'doi.ieeecomputersociety.org'
+        doi_netlog = 'doi.org'
+        if parsed_url.netloc != ieee_netloc and parsed_url.netloc != 'doi.org':
+            modified_url = urlunparse((parsed_url.scheme, ieee_netloc, parsed_url.path,
+                            parsed_url.params, parsed_url.query, parsed_url.fragment))
+            return modified_url
+        else:
+            return url
+
+    def _get_abstract_from_computerorg(self, url):
+        # TODO: handle the case when Chrome is not available
+        driver = webdriver.Chrome()
+        url = self.update_url(url)
+        driver.get(url)
+
+
+        # Wait for the dynamic element to be present on the page
+        element = WebDriverWait(driver, 3).until(EC.presence_of_element_located((By.TAG_NAME, 'article')))
+        # TODO: I'm not sure if this can handle abstracts with multiple paragraphs
+        abstract = element.find_element(By.CLASS_NAME, 'article-content').text
+        driver.quit()
+        return abstract
+    
+    def _get_abstract_from_ieeexplore(self, url):
+        # TODO: handle the case when Chrome is not available
+        driver = webdriver.Chrome()
+        url = self.update_url(url)
+        logger.debug(f'URL: {url}')
+        driver.get(url)
+
+        # Wait for the dynamic element to be present on the page
+        element = WebDriverWait(driver, 2).until(EC.presence_of_element_located((By.CLASS_NAME, 'abstract-text')))
+        temp = element.find_elements(By.CLASS_NAME, 'abstract-text-view-all')
+        if len(temp) > 0:
+            # If there's a view all button
+            view_all = temp[0]
+            driver.execute_script("arguments[0].scrollIntoView(true);", view_all)
+            view_all.click()
+            text = driver.find_element(By.CLASS_NAME, 'abstract-text').text
+        else:
+            text = element.text
+        
+        if text.find('Abstract:\n') >= 0:
+            text = text[text.find('Abstract:\n') + len('Abstract:\n'):]
+        if text.find('\n(Show Less)') >= 0:
+            text = text[:text.find('\n(Show Less)')]
+        
+        driver.close()
+        return text
+    
+    def get_abstract_from_publisher(self, url, _):
+        # TODO: this is super slow. Maybe not Selenium?
+        parsed_url = urlparse(url)
+        ieee_netloc = 'doi.ieeecomputersociety.org'
+        doi_netlog = 'doi.org'
+        if parsed_url.netloc == ieee_netloc:  
+            return self._get_abstract_from_computerorg(url)
+        elif parsed_url.netloc == doi_netlog:
+            return self._get_abstract_from_ieeexplore(url)
+        else:
+            raise NotImplementedError
+
+
+class AbstractUSENIX(BasePaperAbstract):
+    def get_abstract_from_publisher(self, url, authors):
+        r = requests.get(url)
+        logger.debug(f'URL: {url}')
+        assert r.status_code == 200
+
+        html = BeautifulSoup(r.text, 'html.parser')
+
+        abstract_paragraphs = html.find(string=re.compile("Abstract:")).find_next(recursive=False)
+        return abstract_paragraphs.get_text(separator='\n')
+
+
+class AbstractCCS(BasePaperAbstract):
+    def get_abstract_from_publisher(self, url, authors):
+        # TODO: ACM library doesn't like me to crawl and will ban me when upset.
+        logger.debug(f'URL: {url}')
+        r = requests.get(url)
+        assert r.status_code == 200
+
+        html = BeautifulSoup(r.text, 'html.parser')
+        abstract_paragraphs = html.find('div', {'class': 'abstractInFull'})
+        return abstract_paragraphs.get_text(separator='\n')
+        # ap_list = [x.text for x in abstract_paragraphs]
+        # return '\n'.join(ap_list)
+
+NDSS = AbstractNDSS()
+SP = AbstractSP()
+USENIX = AbstractUSENIX()
+CCS = AbstractCCS()
+
+Abstracts = {'NDSS': NDSS,
+             'IEEE S&P': SP,
+             'USENIX': USENIX,
+             'CCS': CCS}
+
+if __name__ == '__main__':
+    logger.setLevel('DEBUG')
+    # SP.get_abstract_from_publisher('https://doi.ieeecomputersociety.org/10.1109/SP46215.2023.00131', [])
+    # SP.get_abstract_from_publisher('https://doi.org/10.1109/SP46215.2023.10179411', [])
+    # print(SP.get_abstract_from_publisher('https://doi.org/10.1109/SP46215.2023.10179381', []))
+    # print(USENIX.get_abstract_from_publisher('https://www.usenix.org/conference/usenixsecurity20/presentation/cremers', []))
+    # print(CCS.get_abstract_from_publisher('https://doi.org/10.1145/3576915.3616615', []))
+    print(NDSS.get_abstract_from_publisher('https://www.ndss-symposium.org/ndss2015/i-do-not-know-what-you-visited-last-summer-protecting-users-third-party-web-tracking', []))

--- a/top4grep/build_db.py
+++ b/top4grep/build_db.py
@@ -7,10 +7,11 @@ from bs4 import BeautifulSoup
 
 from .utils import new_logger
 from .db import Base, Paper
+from .abstract import Abstracts
 
 logger = new_logger("DB")
+logger.setLevel('WARNING')
 
-KEYWORD = "kernel"
 CONFERENCES = ["NDSS", "IEEE S&P", "USENIX", "CCS"]
 NAME_MAP = {
         "NDSS": "ndss",
@@ -24,6 +25,7 @@ Base.metadata.create_all(engine)
 Session = sessionmaker(bind=engine)
 
 def save_paper(conf, year, title, authors, abstract):
+    logger.debug(f'Adding paper {title} with abstract {abstract[:20]}...')
     session = Session()
     paper = Paper(conference=conf, year=year, title=title, authors=", ".join(authors), abstract=abstract)
     session.add(paper)
@@ -32,14 +34,19 @@ def save_paper(conf, year, title, authors, abstract):
 
 def paper_exist(conf, year, title, authors, abstract):
     session = Session()
-    paper = session.query(Paper).filter(Paper.conference==conf, Paper.year==year, Paper.title==title).first()
+    paper = session.query(Paper).filter(Paper.conference==conf, Paper.year==year, Paper.title==title, Paper.abstract==abstract).first()
     session.close()
     return paper is not None
 
-def get_papers(name, year):
+def get_papers(name, year, build_abstract):
     cnt = 0
     conf = NAME_MAP[name]
 
+    if build_abstract and name == "NDSS" and (year == 2018 or year == 2016):
+        logger.warning(f"Skipping the abstract for NDSS {year} becuase the website does not contain abstracts.")
+        extract_abstract = False
+    else:
+        extract_abstract = build_abstract
     try:
         r = requests.get(f"https://dblp.org/db/conf/{conf}/{conf}{year}.html")
         assert r.status_code == 200
@@ -49,7 +56,10 @@ def get_papers(name, year):
         for paper_html in paper_htmls:
             title = paper_html.find('span', {'class': 'title'}).text
             authors = [x.text for x in paper_html.find_all('span', {'itemprop': 'author'})]
-            abstract = ''
+            if extract_abstract:
+                abstract = Abstracts[name].get_abstract(paper_html, title, authors)
+            else:
+                abstract = ''
             # insert the entry only if the paper does not exist
             if not paper_exist(name, year, title, authors, abstract):
                 save_paper(name, year, title, authors, abstract)
@@ -60,7 +70,7 @@ def get_papers(name, year):
     logger.debug(f"Found {cnt} papers at {name}-{year}...")
 
 
-def build_db():
+def build_db(build_abstract):
     for conf in CONFERENCES:
         for year in range(2000, datetime.now().year+1):
-            get_papers(conf, year)
+            get_papers(conf, year, build_abstract)


### PR DESCRIPTION
Add abstract extraction and query. Using `--abstract` for database building and keyword query for abstract.

Known limitations: 

1. Require Chrome browser for IEEE and ACM.

2. Might be banned by ACM library cuz it does not support auto-script visits.