### PR TITLE
Use dblp SPARQL for database initialization

### DIFF
--- a/top4grep/build_db.py
+++ b/top4grep/build_db.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from pathlib import Path
+import re
 
 import requests
 import sqlalchemy
 from sqlalchemy.orm import sessionmaker
-from bs4 import BeautifulSoup
 
 from .utils import new_logger
 from .db import Base, Paper
@@ -20,6 +20,9 @@ NAME_MAP = {
         "USENIX": "uss",
         "CCS": "ccs",
         }
+SPARQL_ENDPOINT = "https://sparql.dblp.org/sparql"
+REQUEST_TIMEOUT = 120
+HEADERS = {"Accept": "application/sparql-results+json"}
 PACKAGE_DIR = Path(__file__).resolve().parent
 DB_PATH = PACKAGE_DIR / "data" / "papers.db"
 
@@ -27,53 +30,113 @@ engine = sqlalchemy.create_engine(f'sqlite:///{str(DB_PATH)}')
 Base.metadata.create_all(engine)
 Session = sessionmaker(bind=engine)
 
-def save_paper(conf, year, title, authors, abstract):
-    logger.debug(f'Adding paper {title} with abstract {abstract[:20]}...')
-    session = Session()
-    paper = Paper(conference=conf, year=year, title=title, authors=", ".join(authors), abstract=abstract)
-    session.add(paper)
-    session.commit()
-    session.close()
 
-def paper_exist(conf, year, title, authors, abstract):
-    session = Session()
-    paper = session.query(Paper).filter(Paper.conference==conf, Paper.year==year, Paper.title==title, Paper.abstract==abstract).first()
-    session.close()
-    return paper is not None
+def clean_author(author):
+    # dblp disambiguates homonyms as "Name 0001"; keep the display name.
+    return re.sub(r"\s+0\d{3}$", "", author).strip()
 
-def get_papers(name, year, build_abstract):
-    cnt = 0
-    conf = NAME_MAP[name]
 
-    if build_abstract and name == "NDSS" and (year == 2018 or year == 2016):
-        logger.warning(f"Skipping the abstract for NDSS {year} becuase the website does not contain abstracts.")
-        extract_abstract = False
-    else:
-        extract_abstract = build_abstract
+def existing_paper_keys():
+    with Session() as session:
+        papers = session.query(Paper.conference, Paper.year, Paper.title, Paper.abstract).all()
+        return set(map(tuple, papers))
+
+
+def save_papers(papers):
+    if not papers:
+        return
+
+    with Session() as session:
+        session.bulk_insert_mappings(Paper, papers)
+        session.commit()
+
+
+def sparql_query():
+    current_year = datetime.now().year
+    streams = " ".join(f'(<https://dblp.org/streams/conf/{NAME_MAP[conf]}> "{conf}")' for conf in CONFERENCES)
+    return f"""
+PREFIX dblp: <https://dblp.org/rdf/schema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+SELECT ?conf ?year ?publ ?title ?ordinal ?author ?url WHERE {{
+  VALUES (?stream ?conf) {{ {streams} }}
+  ?publ dblp:publishedInStream ?stream ;
+        rdf:type dblp:Inproceedings ;
+        dblp:title ?title ;
+        dblp:yearOfPublication ?year ;
+        dblp:hasSignature ?sig .
+  ?sig dblp:signatureDblpName ?author ;
+       dblp:signatureOrdinal ?ordinal .
+  OPTIONAL {{ ?publ dblp:primaryDocumentPage ?url . }}
+  FILTER(?year >= "2000"^^xsd:gYear && ?year <= "{current_year}"^^xsd:gYear)
+}}
+ORDER BY ?conf ?year ?publ xsd:integer(?ordinal)
+"""
+
+
+def fetch_papers():
+    r = requests.get(SPARQL_ENDPOINT, params={"query": sparql_query()}, headers=HEADERS, timeout=REQUEST_TIMEOUT)
+    r.raise_for_status()
+
+    papers = {}
+    for binding in r.json()["results"]["bindings"]:
+        publ = binding["publ"]["value"]
+        if publ not in papers:
+            papers[publ] = {
+                    "conference": binding["conf"]["value"],
+                    "year": int(binding["year"]["value"]),
+                    "title": binding["title"]["value"],
+                    "authors": [],
+                    "publisher_url": binding.get("url", {}).get("value"),
+                    "abstract": "",
+                    }
+        papers[publ]["authors"].append((
+                int(binding["ordinal"]["value"]),
+                clean_author(binding["author"]["value"]),
+                ))
+
+    for paper in papers.values():
+        paper["authors"] = [author for _, author in sorted(paper["authors"])]
+
+    return list(papers.values())
+
+
+def add_abstract(paper):
+    if not paper["publisher_url"]:
+        return
+    if paper["conference"] == "NDSS" and paper["year"] in (2016, 2018):
+        return
+
     try:
-        r = requests.get(f"https://dblp.org/db/conf/{conf}/{conf}{year}.html")
-        assert r.status_code == 200
+        paper["abstract"] = Abstracts[paper["conference"]].get_abstract_from_publisher(
+                paper["publisher_url"], paper["authors"])
+    except Exception:
+        logger.debug(f"Failed to extract abstract from publisher URL {paper['publisher_url']}.")
 
-        html = BeautifulSoup(r.text, 'html.parser')
-        paper_htmls = html.find_all("li", {'class': "inproceedings"})
-        for paper_html in paper_htmls:
-            title = paper_html.find('span', {'class': 'title'}).text
-            authors = [x.text for x in paper_html.find_all('span', {'itemprop': 'author'})]
-            if extract_abstract:
-                abstract = Abstracts[name].get_abstract(paper_html, title, authors)
-            else:
-                abstract = ''
-            # insert the entry only if the paper does not exist
-            if not paper_exist(name, year, title, authors, abstract):
-                save_paper(name, year, title, authors, abstract)
-            cnt += 1
-    except Exception as e:
-        logger.warning(f"Failed to obtain papers at {name}-{year}")
 
-    logger.debug(f"Found {cnt} papers at {name}-{year}...")
+def paper_record(paper):
+    return {
+            "conference": paper["conference"],
+            "year": paper["year"],
+            "title": paper["title"],
+            "authors": ", ".join(paper["authors"]),
+            "abstract": paper["abstract"],
+            }
 
 
 def build_db(build_abstract):
-    for conf in CONFERENCES:
-        for year in range(2000, datetime.now().year+1):
-            get_papers(conf, year, build_abstract)
+    papers = fetch_papers()
+    existing = existing_paper_keys()
+    new_papers = []
+
+    for paper in papers:
+        if build_abstract:
+            add_abstract(paper)
+
+        paper = paper_record(paper)
+        key = (paper["conference"], paper["year"], paper["title"], paper["abstract"])
+        if key not in existing:
+            existing.add(key)
+            new_papers.append(paper)
+
+    save_papers(new_papers)


### PR DESCRIPTION
Fixes DB initialization by replacing the per-year dblp HTML crawl with a single [dblp SPARQL](https://sparql.dblp.org/) query.

The old crawler often failed with dropped connections/rate limiting and skipped many conferences/years. This keeps the existing DB schema and CLI behavior, preserves optional abstract fetching via publisher URLs, and makes `top4grep --build-db` complete successfully in about a second.

Tested with a fresh DB:

```bash
rm -f top4grep/data/papers.db
top4grep --build-db
top4grep -k fuzzing
```
